### PR TITLE
Authentication helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
@@ -11692,6 +11693,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -25686,6 +25692,11 @@
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.3"
       }
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,102 @@
+import jwtDecode from "jwt-decode";
+
+const apiUrl = "http://localhost:3000/api";
+
+// Function used to authenticate a user by their email and password.
+// If successful, will put both auth and refresh tokens into the local storage.
+// If unsuccessful, will throw an error.
+const authenticate = async (email, password) => {
+  const response = await fetch(`${apiUrl}/auth/login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+      password,
+    }),
+  });
+  const responseJson = await response.json();
+
+  if ("errors" in responseJson) {
+    throw new Error(responseJson.errors[0]);
+  }
+
+  localStorage.setItem("authToken", responseJson.authToken);
+  localStorage.setItem("refreshToken", responseJson.refreshToken);
+};
+
+// Function that ensures that the tokens in local storage (if any) are refreshed.
+// If auth token and refresh tokens don't exist in the local storage, does nothing. (User is unauthenticated)
+// If the auth token and refresh tokens exist and both haven't expired, does nothing. (User is authenticated)
+// If the auth token exists, but has expired, and the refresh token that hasn't expired exists,
+// then it will refresh both tokens. (User is authenticated)
+// If both the auth and refresh tokens exist, but have expired, will remove them from local storage. (User is unauthenticated)
+// If both the auth and refresh tokens exist, but are invalid JWT tokens, will remove them from local storage.
+// (user is unauthenticated)
+const ensureTokens = async () => {
+  const localStorageAuthToken = localStorage.getItem("authToken");
+  const localStorageRefreshToken = localStorage.getItem("refreshToken");
+
+  if (localStorageAuthToken && localStorageRefreshToken) {
+    try {
+      const parsedAuth = jwtDecode(localStorageAuthToken);
+      const parsedRefresh = jwtDecode(localStorageRefreshToken);
+
+      // Let's consider tokens that are 30 seconds away from being expired as alaready expired,
+      // to avoid situations where the token expires inbetween sending the request and receiving
+      // the response.
+      const currentTime = Math.floor(Date.now() / 1000) + 30;
+
+      // If auth token has expired but the refresh token is still active
+      if (currentTime > parsedAuth.exp && currentTime <= parsedRefresh.exp) {
+        const response = await fetch(`${apiUrl}/auth/refresh`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            refreshToken: localStorageRefreshToken,
+          }),
+        });
+        const responseJson = await response.json();
+
+        localStorage.setItem("authToken", responseJson.authToken);
+        localStorage.setItem("refreshToken", responseJson.refreshToken);
+      }
+
+      // If both auth and refresh tokens have expired
+      if (currentTime > parsedAuth.exp && currentTime > parsedRefresh.exp) {
+        localStorage.removeItem("authToken");
+        localStorage.removeItem("refreshToken");
+      }
+    } catch {
+      // If refresh or auth tokens are malformed (jwtDecode will throw)
+      localStorage.removeItem("authToken");
+      localStorage.removeItem("refreshToken");
+    }
+  }
+};
+
+// Will send a normal fetch but attach the active auth token to the Authorization header.
+// If the auth token has expired, will first refresh the auth token and THEN send the needed fetch request.
+// This could be used for both authenticated and unauthenticated contexts. If no auth token currently exists,
+// this function will simply not attach the auth header (functionally identical to normal fetch).
+// This function should be used in place of normal fetch calls, because it abstracts the complications
+// of keeping up with the up-to-date auth token.
+const authenticatedFetch = async (url, options) => {
+  await ensureTokens();
+
+  const authToken = localStorage.getItem("authToken");
+  const headers = options?.headers ?? {};
+  const finalHeaders = authToken
+    ? {
+        ...headers,
+        Authorization: `Bearer ${authToken}`,
+      }
+    : headers;
+
+  return await fetch(url, { ...options, headers: finalHeaders });
+};
+
+export { authenticate, authenticatedFetch, apiUrl };

--- a/src/store/sagas.js
+++ b/src/store/sagas.js
@@ -1,8 +1,9 @@
 import { call, put, takeEvery } from "redux-saga/effects";
+import { apiUrl, authenticatedFetch } from "../helpers";
 import { fetchFailed, fetchSuccess } from "./locationsListSlice";
 
 const URL = {
-  base: "http://localhost:3000/api",
+  base: apiUrl,
   all: function () {
     return `${this.base}/locations`;
   },
@@ -22,7 +23,7 @@ const URL = {
 
 export function* fetchLocationsList() {
   try {
-    const response = yield call(fetch, URL.all());
+    const response = yield call(authenticatedFetch, URL.all());
     const locationsList = yield response.json();
     yield put(fetchSuccess(locationsList));
   } catch (e) {
@@ -32,7 +33,7 @@ export function* fetchLocationsList() {
 
 export function* fetchLocation(ID) {
   try {
-    const response = yield call(fetch, URL.byID(ID.payload));
+    const response = yield call(authenticatedFetch, URL.byID(ID.payload));
     const location = yield response.json();
     yield put(fetchSuccess(location));
   } catch (e) {
@@ -45,7 +46,7 @@ export function* fetchByInput(value) {
     // console.log(new URLSearchParams(input.payload).toString());  this has = at the end
     const input = encodeURIComponent(value.payload).replace("%20", "+");
 
-    const response = yield call(fetch, URL.byInput(input));
+    const response = yield call(authenticatedFetch, URL.byInput(input));
     const locations = yield response.json();
     yield put(fetchSuccess(locations));
   } catch (e) {
@@ -55,7 +56,7 @@ export function* fetchByInput(value) {
 
 export function* fetchByCategory(category) {
   try {
-    const response = yield call(fetch, URL.byCategory(category.payload));
+    const response = yield call(authenticatedFetch, URL.byCategory(category.payload));
     const locations = yield response.json();
     yield put(fetchSuccess(locations));
   } catch (e) {
@@ -66,7 +67,7 @@ export function* fetchByCategory(category) {
 export function* fetchByHashtag(hashtag) {
   try {
     console.log(hashtag.payload, "hashtag for search");
-    const response = yield call(fetch, URL.byHashTag(hashtag.payload));
+    const response = yield call(authenticatedFetch, URL.byHashTag(hashtag.payload));
     const locations = yield response.json();
     yield put(fetchSuccess(locations));
   } catch (e) {


### PR DESCRIPTION
Implement authentication helpers to be used on the frontend: 

* `authenticate` - A function that should be called while submitting a login form. If successful, will store auth and refresh tokens in the local storage. Will throw an error on email and password mismatch.
* `authenticatedFetch` - A wrapper over the normal fetch function. Behaves exactly the same as the normal fetch function, but will attach the auth token to the `Authorization` header. If the current auth token has expired, will FIRST refresh the auth token, and THEN send the original fetch request with the attached `Authorization` header.